### PR TITLE
a way to jump to the abstract page changed

### DIFF
--- a/_includes/programs.html
+++ b/_includes/programs.html
@@ -18,7 +18,7 @@
                     <tr>
                         <td>{{ session.time }}</td>
                         <td>{{ session.type }}</td>
-                        <td>{% if session.type %}<a href="{{ site.baseurl }}/program-detail/#{{ session.tag }}">{{ session.title }}</a>{% else %}{{ session.title }}{% endif %}</td>
+                        <td>{% if session.tag %}<a href="{{ site.baseurl }}/program-detail/#{{ session.tag }}">{{ session.title }}</a>{% else %}{{ session.title }}{% endif %}</td>
                         <td>
                         {% for presenter in session.presenters %}
                             {{ presenter.name_and_title }}</br >


### PR DESCRIPTION
a link to program detail page now based on the presence of session.tag instead of session.type.